### PR TITLE
ollama 1.2.1 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biorecap
 Title: Retrieve and summarize bioRxiv preprints with a local LLM using ollama
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Stephen", "Turner", , "vustephen@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9140-9028"))
@@ -12,7 +12,7 @@ Depends:
     R (>= 4.2.0)
 Imports: 
     dplyr,
-    ollamar,
+    ollamar (>= 1.2.1),
     rlang,
     rmarkdown,
     tidyRSS,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# biorecap 0.1.1
+
+- Fix bug in `add_summary()` caused by upstream changes in ollamar (fixes #1).
+- Bumped minimum required version of ollamar to 1.2.1.
+
 # biorecap 0.1.0
 
-Initial release.
+- Initial release.

--- a/R/biorecap.R
+++ b/R/biorecap.R
@@ -154,7 +154,7 @@ add_summary <- function(preprints, model="llama3.1") {
   suppressMessages({
     preprints <-
       preprints |>
-      dplyr::mutate("summary" = as.vector(sapply(.data$prompt, \(x) ollamar::generate(model=model, prompt=x, output="text")$response)))
+      dplyr::mutate("summary" = as.vector(sapply(.data$prompt, \(x) ollamar::generate(model=model, prompt=x, output="text"))))
   })
 
   # Remove newlines anywhere within any text


### PR DESCRIPTION
- Fix bug in `add_summary()` caused by upstream changes in ollamar (fixes #1).
- Bumped minimum required version of ollamar to 1.2.1.

Thanks @huyvuong 